### PR TITLE
Fix LazyChain iterator reset

### DIFF
--- a/lazy_evaluation/lazy.go
+++ b/lazy_evaluation/lazy.go
@@ -150,6 +150,9 @@ func (lc *LazyChain) HasOperations() bool {
 
 // Collect evaluates the lazy chain and returns all results
 func (lc *LazyChain) Collect() ([]interface{}, error) {
+	// Reset the underlying iterator so multiple calls work correctly
+	lc.iterator.Reset()
+
 	// Build the iterator chain
 	currentIterator := lc.iterator
 
@@ -187,6 +190,8 @@ func (lc *LazyChain) Collect() ([]interface{}, error) {
 
 // ForEach applies a function to each element without collecting results
 func (lc *LazyChain) ForEach(fn func(interface{}) error) error {
+	// Reset the underlying iterator so each call processes all elements
+	lc.iterator.Reset()
 	currentIterator := lc.iterator
 
 	// Apply filters first

--- a/lazy_evaluation/lazy_test.go
+++ b/lazy_evaluation/lazy_test.go
@@ -1,0 +1,51 @@
+package lazy
+
+import "testing"
+
+func TestLazyChainCollectReset(t *testing.T) {
+	lc := NewLazyChain([]interface{}{1, 2, 3})
+	lc.AddMap(func(i interface{}) (interface{}, error) { return i.(int) * 2, nil })
+
+	first, err := lc.Collect()
+	if err != nil {
+		t.Fatalf("first collect error: %v", err)
+	}
+	second, err := lc.Collect()
+	if err != nil {
+		t.Fatalf("second collect error: %v", err)
+	}
+
+	if len(first) != len(second) {
+		t.Fatalf("expected same length, got %d and %d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("results differ: %v vs %v", first, second)
+		}
+	}
+}
+
+func TestLazyChainForEachReset(t *testing.T) {
+	lc := NewLazyChain([]interface{}{1, 2, 3})
+	sum1 := 0
+	if err := lc.ForEach(func(i interface{}) error {
+		sum1 += i.(int)
+		return nil
+	}); err != nil {
+		t.Fatalf("first ForEach error: %v", err)
+	}
+	if sum1 != 6 {
+		t.Fatalf("expected sum 6, got %d", sum1)
+	}
+
+	sum2 := 0
+	if err := lc.ForEach(func(i interface{}) error {
+		sum2 += i.(int)
+		return nil
+	}); err != nil {
+		t.Fatalf("second ForEach error: %v", err)
+	}
+	if sum2 != 6 {
+		t.Fatalf("expected sum 6 again, got %d", sum2)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure LazyChain resets its iterator before Collect and ForEach
- add regression tests covering repeated Collect and ForEach calls

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68604d6a37408327971ad6c0364e8d8b